### PR TITLE
Implement beta statistics

### DIFF
--- a/R/cajorls.R
+++ b/R/cajorls.R
@@ -1,5 +1,5 @@
 cajorls <- function(z, r = 1, reg.number = NULL){
-    if (!(class(z) == "ca.jo") && !(class(z) == "cajo.test")) {
+    if ((!inherits(z, "ca.jo")) && (!inherits(z, "cajo.test"))) {
         stop("\nPlease, provide object of class 'ca.jo' or 'cajo.test' as 'z'.\n")
     }
     P <- ncol(z@Z0)
@@ -27,10 +27,40 @@ cajorls <- function(z, r = 1, reg.number = NULL){
         }
         form1 <- formula(paste("z@Z0[, reg.number]", text2, "-1"))
         rlm <- lm(substitute(form1), data = data.mat)
+		return(list(rlm = rlm, beta = betanorm))
     }
     else if (is.null(reg.number)) {
         form1 <- formula(paste("z@Z0", text2, "-1"))
         rlm <- lm(substitute(form1), data = data.mat)
+		# compute beta statistics
+		ZK2 <- z@ZK[, -r] # Y(-1) (2)
+		M <- diag(nrow(z@ZK)) - z@Z1 %*% solve(crossprod(z@Z1)) %*% t(z@Z1)
+		alpha <- matrix(coef(rlm)[1:r, ], ncol = r, byrow = T) # the coefficients on ecm
+		rownames(alpha) <- colnames(coef(rlm)[1:r, ])
+		SIGMA <- crossprod(resid(rlm)) / nrow(z@ZK)
+		beta.se <- sqrt(diag(kronecker(
+		  solve(t(ZK2) %*% M %*% ZK2),
+		  solve(t(alpha) %*% solve(SIGMA) %*% alpha)
+		)))
+		beta.se <- matrix(c(rep(NA, r), beta.se), ncol = r, byrow = T)
+		for (i in 1:r) {
+		  beta.se[i, ] <- NA
+		}
+		rownames(beta.se) <- rownames(beta)
+		colnames(beta.se) <- colnames(beta)
+		beta.t <- betanorm / beta.se
+		beta.pval <- 2 * pt(abs(beta.t), df = rlm$df.residual, lower.tail = F)
+		if (r == 1) {
+		  beta.stats <- data.frame(cbind(betanorm, beta.se, beta.t, beta.pval))
+		  colnames(beta.stats) <- c("Estimate", "Std. Error", "t value", "Pr(>|t|)")
+		} else {
+		  beta.stats <- list()
+		  for (ect in 1:ncol(beta)) {
+			beta.ect <- data.frame(cbind(round(betanorm[, ect], digits = 15), beta.se[, ect], beta.t[, ect], beta.pval[, ect]))
+			colnames(beta.ect) <- c("Estimate", "Std. Error", "t value", "Pr(>|t|)")
+			beta.stats[[ect]] <- beta.ect
+		  }
+		}
+		return(list(rlm = rlm, beta = betanorm, beta.stats = beta.stats))
     }
-    return(list(rlm = rlm, beta = betanorm))
 }


### PR DESCRIPTION
Implement cointegration matrix (beta) statistics like standard error, t statistic, p value as in Lütkepohl's Applied Time Series Econometrics pp. 96-100.

In order to access this functionality, the user should call for $beta.stats. For example:
```
vecm.r <- cajorls(cajo, r = 2) # reg.number = NULL
vecm.r$beta.stats
```